### PR TITLE
Password protect redis

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -6,7 +6,7 @@ const Docker = require("dockerode");
 const docker = new Docker({ socketPath: "/var/run/docker.sock" });
 const fetch = require("node-fetch");
 const redis = require("redis");
-const client = redis.createClient();
+const client = redis.createClient({ auth_pass: "foobared" });
 const RedisSMQ = require("rsmq");
 const sgMail = require("@sendgrid/mail");
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
@@ -23,7 +23,8 @@ const SESSIONS_OBJ = process.env.SESSIONS_OBJ;
 const rsmq = new RedisSMQ({
   host: REDIS_HOST,
   port: REDIS_PORT,
-  ns: NAMESPACE
+  ns: NAMESPACE,
+  auth_pass: "foobared"
 });
 
 const getSessionData = req => {

--- a/helpers.js
+++ b/helpers.js
@@ -6,7 +6,8 @@ const Docker = require("dockerode");
 const docker = new Docker({ socketPath: "/var/run/docker.sock" });
 const fetch = require("node-fetch");
 const redis = require("redis");
-const client = redis.createClient({ auth_pass: "foobared" });
+const REDIS_PW = process.env.REDIS_PW;
+const client = redis.createClient({ auth_pass: REDIS_PW });
 const RedisSMQ = require("rsmq");
 const sgMail = require("@sendgrid/mail");
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
@@ -24,7 +25,7 @@ const rsmq = new RedisSMQ({
   host: REDIS_HOST,
   port: REDIS_PORT,
   ns: NAMESPACE,
-  auth_pass: "foobared"
+  auth_pass: REDIS_PW
 });
 
 const getSessionData = req => {

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -9,8 +9,8 @@ const SSLCERT = process.env.SSLCERT;
 const SESSIONS_OBJ = process.env.SESSIONS_OBJ;
 const fs = require("fs");
 const redis = require("redis");
-const client = redis.createClient();
-client.auth("foobared");
+const client = redis.createClient({ password: "foobared" });
+// client.auth("foobared");
 
 const proxyToHTTPSServer = httpProxy.createProxyServer();
 

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -10,7 +10,6 @@ const SESSIONS_OBJ = process.env.SESSIONS_OBJ;
 const fs = require("fs");
 const redis = require("redis");
 const client = redis.createClient({ auth_pass: "foobared" });
-// client.auth("foobared");
 
 const proxyToHTTPSServer = httpProxy.createProxyServer();
 

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -7,9 +7,10 @@ const ROOT = process.env.ROOT;
 const SSLKEY = process.env.SSLKEY;
 const SSLCERT = process.env.SSLCERT;
 const SESSIONS_OBJ = process.env.SESSIONS_OBJ;
+const REDIS_PW = process.env.REDIS_PW;
 const fs = require("fs");
 const redis = require("redis");
-const client = redis.createClient({ auth_pass: "foobared" });
+const client = redis.createClient({ auth_pass: REDIS_PW });
 
 const proxyToHTTPSServer = httpProxy.createProxyServer();
 

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -94,7 +94,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.loadNotebook(req, res);
         } else {
           console.log("Proxying request through websocket");
-          client.auth("topsecret");
+          client.auth("foobared");
           helpers
             .getSessionData(req)
             .then(sessionData => {

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -9,7 +9,7 @@ const SSLCERT = process.env.SSLCERT;
 const SESSIONS_OBJ = process.env.SESSIONS_OBJ;
 const fs = require("fs");
 const redis = require("redis");
-const client = redis.createClient({ password: "foobared" });
+const client = redis.createClient({ auth_pass: "foobared" });
 // client.auth("foobared");
 
 const proxyToHTTPSServer = httpProxy.createProxyServer();

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -10,6 +10,7 @@ const SESSIONS_OBJ = process.env.SESSIONS_OBJ;
 const fs = require("fs");
 const redis = require("redis");
 const client = redis.createClient();
+client.auth("foobared");
 
 const proxyToHTTPSServer = httpProxy.createProxyServer();
 
@@ -94,7 +95,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.loadNotebook(req, res);
         } else {
           console.log("Proxying request through websocket");
-          client.auth("foobared");
+
           helpers
             .getSessionData(req)
             .then(sessionData => {

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -94,6 +94,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.loadNotebook(req, res);
         } else {
           console.log("Proxying request through websocket");
+          client.auth("topsecret");
           helpers
             .getSessionData(req)
             .then(sessionData => {

--- a/redisWorker.js
+++ b/redisWorker.js
@@ -9,7 +9,8 @@ const REDIS_PORT = process.env.REDIS_PORT;
 const rsmq = new RedisSMQ({
   host: REDIS_HOST,
   port: REDIS_PORT,
-  ns: NAMESPACE
+  ns: NAMESPACE,
+  auth_pass: "foobared"
 });
 
 const startRedisWorker = () => {

--- a/redisWorker.js
+++ b/redisWorker.js
@@ -5,12 +5,13 @@ const QUEUENAME = process.env.QUEUENAME;
 const NAMESPACE = process.env.NAMESPACE;
 const REDIS_HOST = process.env.REDIS_HOST;
 const REDIS_PORT = process.env.REDIS_PORT;
+const REDIS_PW = process.env.REDIS_PW;
 
 const rsmq = new RedisSMQ({
   host: REDIS_HOST,
   port: REDIS_PORT,
   ns: NAMESPACE,
-  auth_pass: "foobared"
+  auth_pass: REDIS_PW
 });
 
 const startRedisWorker = () => {


### PR DESCRIPTION
# What 
- Updated redis config file to require `AUTH` command and password to authenticate redis clients.
- node_redis, and redisSMQ now take a `pass_auth` k/v in their options objects
- password is stored in an environment variable
