### PR TITLE
Dispatch server cleanup

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -35,7 +35,7 @@ const getSessionData = req => {
         rej(err);
       } else {
         let parsedSessionData = JSON.parse(string);
-        console.log("parsedSessionData : ", parsedSessionData);
+        // console.log("parsedSessionData : ", parsedSessionData);
         res(parsedSessionData);
       }
     });
@@ -141,7 +141,7 @@ const startNewSession = (req, res) => {
     notebookId = matchData[1];
   }
 
-  console.log("Notebook ID : ", notebookId);
+  // console.log("Notebook ID : ", notebookId);
 
   const html = fs.readFileSync(__dirname + "/redirect.html", {
     encoding: "utf-8"
@@ -165,13 +165,13 @@ const startNewSession = (req, res) => {
 
   docker.createContainer(options, (err, container) => {
     const containerId = container.id;
-    console.log("Id of this container is " + containerId);
+    // console.log("Id of this container is " + containerId);
 
     container.start((err, data) => {
       if (err) console.log(err);
       container.inspect(container.id).then(data => {
         const IPAddress = data.NetworkSettings.IPAddress;
-        console.log("IP address of this container is: " + IPAddress);
+        // console.log("IP address of this container is: " + IPAddress);
 
         const containerURL = `http://${IPAddress}:${PORT}`;
 
@@ -210,7 +210,7 @@ const teardownZombieContainers = () => {
     client.hvals(SESSIONS_OBJ, (err, sessionData) => {
       const allSessionData = sessionData.map(val => JSON.parse(val));
       const sessionContainerIds = allSessionData.map(data => data.containerId);
-      log("session container Ids : ", sessionContainerIds);
+      // log("session container Ids : ", sessionContainerIds);
 
       // kill container if no session exists
       containers.forEach(containerInfo => {

--- a/helpers.js
+++ b/helpers.js
@@ -224,7 +224,6 @@ const teardownZombieContainers = () => {
 
 const log = (...messages) => {
   let date = new Date();
-  messages = Array.from(messages);
   console.log("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
   console.log(String(date));
   messages.forEach(mesg => console.log(mesg));

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -95,7 +95,10 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.loadNotebook(req, res);
         } else {
           helpers.log("Proxying request through websocket");
-
+          helpers.log(
+            "`Last visited` property on session : ",
+            sessionData.lastVisited
+          );
           sessionData.lastVisited = Date.now();
           client.hset(
             SESSIONS_OBJ,

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -76,7 +76,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
         helpers.log("Inside host !== ROOT", `HOST: ${host}`);
 
         if (req.method === "DELETE") {
-          console.log("Delete Request received");
+          helpers.log("Delete Request received");
           // server.js issues delete request to tear down a container session
           helpers.tearDown(req, res);
         } else if (
@@ -87,14 +87,14 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.saveOrCloneNotebook(req, res);
         } else if (!sessionData) {
           // subdomain is not in the sessions object
-          console.log("Could not find session");
+          helpers.log("Could not find session");
           res.writeHead(404);
           return res.end();
         } else if (req.url === "/loadNotebook" && req.method === "GET") {
           // load notebook from session state if stashed notebookId
           helpers.loadNotebook(req, res);
         } else {
-          console.log("Proxying request through websocket");
+          helpers.log("Proxying request through websocket");
 
           helpers
             .getSessionData(req)
@@ -110,7 +110,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
               );
             })
             .catch(err => {
-              console.log(err);
+              helpers.log(err);
             });
         }
       }
@@ -122,7 +122,7 @@ helpers.teardownZombieContainers();
 helpers.createQueue();
 
 proxyServer.on("upgrade", (req, socket, head) => {
-  console.log("Inside Upgrade Listener");
+  helpers.log("Inside Upgrade Listener");
   helpers
     .getSessionData(req)
     .then(sessionData => {
@@ -131,7 +131,7 @@ proxyServer.on("upgrade", (req, socket, head) => {
       }
     })
     .catch(err => {
-      console.log(err);
+      helpers.log(err);
     });
 });
 

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -96,22 +96,32 @@ const proxyServer = https.createServer(https_options, (req, res) => {
         } else {
           helpers.log("Proxying request through websocket");
 
-          helpers
-            .getSessionData(req)
-            .then(sessionData => {
-              sessionData.lastVisited = Date.now();
-              client.hset(
-                SESSIONS_OBJ,
-                req.headers.host,
-                JSON.stringify(sessionData),
-                (err, result) => {
-                  proxy.web(req, res, { target: sessionData.ip }, e => {});
-                }
-              );
-            })
-            .catch(err => {
-              helpers.log(err);
-            });
+          sessionData.lastVisited = Date.now();
+          client.hset(
+            SESSIONS_OBJ,
+            req.headers.host,
+            JSON.stringify(sessionData),
+            (err, result) => {
+              proxy.web(req, res, { target: sessionData.ip }, e => {});
+            }
+          );
+
+          // helpers
+          //   .getSessionData(req)
+          //   .then(sessionData => {
+          //     sessionData.lastVisited = Date.now();
+          //     client.hset(
+          //       SESSIONS_OBJ,
+          //       req.headers.host,
+          //       JSON.stringify(sessionData),
+          //       (err, result) => {
+          //         proxy.web(req, res, { target: sessionData.ip }, e => {});
+          //       }
+          //     );
+          //   })
+          //   .catch(err => {
+          //     helpers.log(err);
+          //   });
         }
       }
     })

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -95,7 +95,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.loadNotebook(req, res);
         } else if (req.headers.connection === "keep-alive") {
           helpers.log("Proxying request through websocket");
-          helpers.log("REQUEST HEADERS INSIDE PROXY : ", req.headers);
+          // helpers.log("REQUEST HEADERS INSIDE PROXY : ", req.headers);
           sessionData.lastVisited = Date.now();
           client.hset(
             SESSIONS_OBJ,

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -23,10 +23,10 @@ const proxy = httpProxy.createProxyServer({
 // ~~~~~~~~~~~~~~~
 // Redirect all traffic from http to https
 const httpServer = http.createServer((req, res) => {
-  helpers.log("Inside httpServer, req.headers.host =", req.headers.host);
+  // helpers.log("Inside httpServer, req.headers.host =", req.headers.host);
 
   if (/redpointnotebooks/.test(req.headers.host)) {
-    helpers.log("Redirecting to HTTPS");
+    // helpers.log("Redirecting to HTTPS");
     proxyToHTTPSServer.web(req, res, {
       target: `https://${req.headers.host}${req.url}`
     });
@@ -37,7 +37,7 @@ const httpServer = http.createServer((req, res) => {
 });
 
 httpServer.listen(80, () => {
-  helpers.log("HTTP Redirect server listening on port 80...");
+  // helpers.log("HTTP Redirect server listening on port 80...");
 });
 // ~~~~~~~~~~~~~~~
 
@@ -55,12 +55,12 @@ const proxyServer = https.createServer(https_options, (req, res) => {
     .getSessionData(req)
     .then(sessionData => {
       if (host === ROOT) {
-        helpers.log(
-          "Inside host === ROOT",
-          `Host: ${host}`,
-          `req.method: ${req.method}`,
-          req.method
-        );
+        // helpers.log(
+        //   "Inside host === ROOT",
+        //   `Host: ${host}`,
+        //   `req.method: ${req.method}`,
+        //   req.method
+        // );
 
         if (req.method === "GET") {
           helpers.startNewSession(req, res);
@@ -73,11 +73,11 @@ const proxyServer = https.createServer(https_options, (req, res) => {
         }
       } else if (host !== ROOT) {
         // host === subdomained url
-        helpers.log("Inside host !== ROOT", `HOST: ${host}`);
+        // helpers.log("Inside host !== ROOT", `HOST: ${host}`);
 
         if (req.method === "DELETE") {
           // server.js issues delete request to tear down a container session
-          helpers.log("Delete Request received");
+          // helpers.log("Delete Request received");
           helpers.tearDown(req, res);
         } else if (
           req.method === "POST" &&
@@ -87,14 +87,14 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.saveOrCloneNotebook(req, res);
         } else if (!sessionData) {
           // subdomain is not in the sessions object
-          helpers.log("Could not find session");
+          // helpers.log("Could not find session");
           res.writeHead(404);
           return res.end();
         } else if (req.url === "/loadNotebook" && req.method === "GET") {
           // load notebook from session state if stashed notebookId
           helpers.loadNotebook(req, res);
         } else {
-          helpers.log("Proxying request through websocket");
+          // helpers.log("Proxying request through websocket");
           // helpers.log("REQUEST HEADERS INSIDE PROXY : ", req.headers);
           sessionData.lastVisited = Date.now();
           client.hset(
@@ -129,5 +129,5 @@ proxyServer.on("upgrade", (req, socket, head) => {
 });
 
 proxyServer.listen(443, () => {
-  helpers.log("Listening on port 443...");
+  // helpers.log("Listening on port 443...");
 });

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -76,8 +76,8 @@ const proxyServer = https.createServer(https_options, (req, res) => {
         helpers.log("Inside host !== ROOT", `HOST: ${host}`);
 
         if (req.method === "DELETE") {
-          helpers.log("Delete Request received");
           // server.js issues delete request to tear down a container session
+          helpers.log("Delete Request received");
           helpers.tearDown(req, res);
         } else if (
           req.method === "POST" &&
@@ -95,7 +95,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.loadNotebook(req, res);
         } else {
           helpers.log("Proxying request through websocket");
-
+          helpers.log("REQUEST HEADERS INSIDE PROXY : ", req.headers);
           sessionData.lastVisited = Date.now();
           client.hset(
             SESSIONS_OBJ,

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -93,7 +93,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
         } else if (req.url === "/loadNotebook" && req.method === "GET") {
           // load notebook from session state if stashed notebookId
           helpers.loadNotebook(req, res);
-        } else {
+        } else if (req.headers.connection === "keep-alive") {
           helpers.log("Proxying request through websocket");
           helpers.log("REQUEST HEADERS INSIDE PROXY : ", req.headers);
           sessionData.lastVisited = Date.now();

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -93,7 +93,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
         } else if (req.url === "/loadNotebook" && req.method === "GET") {
           // load notebook from session state if stashed notebookId
           helpers.loadNotebook(req, res);
-        } else if (req.headers.connection === "keep-alive") {
+        } else {
           helpers.log("Proxying request through websocket");
           // helpers.log("REQUEST HEADERS INSIDE PROXY : ", req.headers);
           sessionData.lastVisited = Date.now();

--- a/proxyServer.js
+++ b/proxyServer.js
@@ -95,10 +95,7 @@ const proxyServer = https.createServer(https_options, (req, res) => {
           helpers.loadNotebook(req, res);
         } else {
           helpers.log("Proxying request through websocket");
-          helpers.log(
-            "`Last visited` property on session : ",
-            sessionData.lastVisited
-          );
+
           sessionData.lastVisited = Date.now();
           client.hset(
             SESSIONS_OBJ,
@@ -108,23 +105,6 @@ const proxyServer = https.createServer(https_options, (req, res) => {
               proxy.web(req, res, { target: sessionData.ip }, e => {});
             }
           );
-
-          // helpers
-          //   .getSessionData(req)
-          //   .then(sessionData => {
-          //     sessionData.lastVisited = Date.now();
-          //     client.hset(
-          //       SESSIONS_OBJ,
-          //       req.headers.host,
-          //       JSON.stringify(sessionData),
-          //       (err, result) => {
-          //         proxy.web(req, res, { target: sessionData.ip }, e => {});
-          //       }
-          //     );
-          //   })
-          //   .catch(err => {
-          //     helpers.log(err);
-          //   });
         }
       }
     })


### PR DESCRIPTION
Commits of note:
**"remove redundant invocation of helpers.getSessionData"**
- We had nested calls to `helpers.getSessionData`. Removed the inner call within the fall-through if/else for `ws` proxying. `sessionData` has already been retrieved by the outer invocation and is in scope here.

---
Seemed to be working, but I reverted this commit. Might be something there. 
**"make explicit `else if` branch for `ws` proxying"**
- inspects the `connection` property on `req.headers`.
- if === "keep-alive", proxy the websocket message


